### PR TITLE
Fixed errors in %I and %p

### DIFF
--- a/jquery.relatize_date.js
+++ b/jquery.relatize_date.js
@@ -42,10 +42,10 @@
           case 'c': return date.toString(); break;
           case 'd': return pad(date.getDate()); break;
           case 'H': return pad(hours); break;
-          case 'I': return pad((hours + 12) % 12); break;
+          case 'I': return pad(hours > 12 ? hours - 12 : hours); break;
           case 'm': return pad(month + 1); break;
           case 'M': return pad(minutes); break;
-          case 'p': return hours > 12 ? 'PM' : 'AM'; break;
+          case 'p': return hours > 11 ? 'PM' : 'AM'; break;
           case 'S': return pad(date.getSeconds()); break;
           case 'w': return day; break;
           case 'y': return pad(date.getFullYear() % 100); break;


### PR DESCRIPTION
Fixed errors in the date format function relating to the AM/PM output (%p) and the 12-hour cycle format (%I).

Most of the errors I have found are relating to what happens around noon.  For example 

2011-05-23T12:00:00 was being reported as May 23 2011 00:00 when the correct format should have been May 23 2011 12:00 for 24-hour time and May 23 2011 12:00 PM for 12-hour time.
